### PR TITLE
Feature: Allow quering public neo4j apis

### DIFF
--- a/app/annotation_controller.py
+++ b/app/annotation_controller.py
@@ -75,7 +75,7 @@ def handle_client_request(query, request, node_types):
             "title": title,
             "node_types": node_types,
             "status": TaskStatus.PENDING.value,
-            "job_id": app.config["job_id"],
+            "job_id": app.config.get("job_id", "N/A"),
         }
 
         annotation_id = AnnotationStorageService.save(annotation)

--- a/app/routes.py
+++ b/app/routes.py
@@ -46,6 +46,14 @@ CORS(app)
 @app.route("/schema", methods=["GET"])
 def get_schema():
     response = schema_by_source()
+    if isinstance(response, list):
+        response = {}
+        response["schema"] = schema_manager.schema
+    
+    if len(response['schema']['nodes']) == 0:
+        response = {}
+        response["schema"] = schema_manager.schema
+
     return Response(json.dumps(response, indent=4), mimetype='application/json')
 
 @socketio.on("connect")
@@ -471,7 +479,7 @@ def run_query_directly():
         logging.error(f"Error running query: {e}")
         return jsonify({"error": str(e)}), 500
 
-@app.route("/load_schema", methods=["GET"])
+@app.route("/load-schema-external", methods=["GET"])
 def get_neo4j_schema():
     try:
         data_path = "/"

--- a/app/routes.py
+++ b/app/routes.py
@@ -42,41 +42,11 @@ EXP = os.getenv("REDIS_EXPIRATION", 3600)  # expiration time of redis cache
 CORS(app)
 
 
-@app.route("/schema-list", methods=["GET"])
-def get_schema_list():
-    schema_list = schema_manager.schema_list
-    response = {
-        "schemas": schema_list,
-    }
-    return Response(json.dumps(response, indent=4), mimetype="application/json")
-
 
 @app.route("/schema", methods=["GET"])
 def get_schema():
-    try:
-        response = {"nodes": [], "edges": []}
-
-        schema = schema_manager.schema
-        nodes = schema["nodes"]
-        edges = schema["edges"]
-
-        for label, node in nodes.items():
-            node_input = {"label": label, "properties": node["properties"]}
-            response["nodes"].append(node_input)
-
-        for label, edge in edges.items():
-            edge_input = {
-                "label": label,
-                "source": edge["source"],
-                "target": edge["target"],
-                "properties": edge["properties"],
-            }
-            response["edges"].append(edge_input)
-        return Response(json.dumps(response, indent=4), mimetype="application/json")
-    except Exception as e:
-        logging.error(f"Error fetching schema: {e}")
-        return jsonify({"error": str(e)}), 500
-
+    response = schema_by_source()
+    return Response(json.dumps(response, indent=4), mimetype='application/json')
 
 @socketio.on("connect")
 def on_connect(args):
@@ -456,8 +426,7 @@ def load_data():
             # Add other database instances here
         }
 
-        database_type = config["database"][type]
-        db_instance = databases[database_type]()
+        db_instance = databases[type]()
 
         if type == 'cypher':
             db_instance.set_tenant_id(folder_id)
@@ -501,3 +470,79 @@ def run_query_directly():
     except Exception as e:
         logging.error(f"Error running query: {e}")
         return jsonify({"error": str(e)}), 500
+
+@app.route("/load_schema", methods=["GET"])
+def get_neo4j_schema():
+    try:
+        data_path = "/"
+        # load database config
+        databases = {
+            "metta": lambda: MeTTa_Query_Generator(data_path),
+            "cypher": lambda: CypherQueryGenerator(data_path),
+            # Add other database instances here
+        }
+
+        db_instance = databases["cypher"]()
+
+        app.config["db_instance"] = db_instance
+
+        result = db_instance.get_schema()
+
+        #Load Schema
+        schema_manager.schema = result
+
+        formatted_response = json.dumps(schema_manager.schema, indent=4)
+
+        return Response(formatted_response, mimetype="application/json")
+    except Exception as e:
+        logging.error(f"Error getting schema: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+def schema_by_source():
+    try:
+        response = {'schema': {'nodes': [], 'edges': []}}
+
+        schema = schema_manager.schema
+
+        for key, value in schema['nodes'].items():
+            response['schema']['nodes'].append({
+                'data': {
+                'name': value['label'],
+                'properites':[property for property in value['properties'].keys()]
+                }
+            })
+
+        for key, value in schema['edges'].items():
+            is_new = True
+            for ed in response['schema']['edges']:
+                if value['source'] == ed['data']['source'] and value['target'] == ed['data']['target']:
+                    is_new = False
+                    ed['data']['possible_connection'].append( value.get('input_label') or value.get('output_label') or 'unknown')
+            if is_new:
+                response['schema']['edges'].extend(flatten_edges(value))
+
+        return response
+    except Exception as e:
+        logging.error(f"Error fetching schema: {e}")
+        return []
+
+def node_exists(response, name):
+    name = name.strip().lower()
+    return any(n['data']['name'].strip().lower() == name for n in response['schema']['nodes'])
+
+def flatten_edges(value):
+    sources = value['source'] if isinstance(value['source'], list) else [value['source']]
+    targets = value['target'] if isinstance(value['target'], list) else [value['target']]
+    label = value.get('input_label') or value.get('output_label') or 'unknown'
+
+    return [
+        {'data': {
+            'source': src,
+            'target': tgt,
+            'possible_connection': [label]
+            }
+        for src in sources
+        for tgt in targets
+        }
+    ]

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -300,7 +300,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         else:
             count_clause = ''
             for node in query_clauses['list_of_node_ids']:
-                count_clause += f"COUNT(DISTINCT {node}) AS {node}_{node_map[node]['type']}, "
+                count_clause += f"COUNT(DISTINCT {node}) AS {node}_{node_map[node]['type'].replace(' ', '_').replace(':', 'ZzZ')}, "
             return_clause = "RETURN " + count_clause.rstrip(', ')
             label_count_query = f'''{match_no_clause} {where_no_clause} {return_clause}'''
 
@@ -522,68 +522,55 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
 
     def get_schema(self):
-        query = "CALL db.schema.visualization()"
-
+        query = """
+        MATCH (a)-[r]->(b)
+        RETURN DISTINCT
+          labels(a) AS from_labels,
+          type(r) AS rel_type,
+          labels(b) AS to_labels
+        """
         results = self.run_query(query)
 
-        results = results[0]
-
-        neo4j_nodes = results['nodes']
-        neo4j_edges = results['relationships']
-
-
         edges = {}
-
         nodes = {}
-        # process neo4j edges
-        for neo4j_edge in neo4j_edges:
-            source_node, target_node = neo4j_edge.nodes
-            source_label = next(iter(source_node.labels))
-            target_label = next(iter(target_node.labels))
 
-            nodes[source_label] = {
-                "label": source_label,
-                "properties": {
-                }
-            }
+        for result in results:
+            source_labels = result["from_labels"]
+            target_labels = result["to_labels"]
+            rel_type = result["rel_type"]
 
-            nodes[target_label] = {
-                "label": target_label,
-                "properties": {
+            # Use only the first label per node (common in most schemas)
+            source_label = source_labels[0] if source_labels else "Unknown"
+            target_label = target_labels[0] if target_labels else "Unknown"
 
-                }
-            }
+            nodes[source_label] = {"label": source_label, "properties": []}
+            nodes[target_label] = {"label": target_label, "properties": []}
 
-            id = neo4j_edge.type
-
-            if id not in edges:
-                edges[id] = {
-                    "source": next(iter(source_node.labels)),
-                    "target": next(iter(target_node.labels)),
-                    "properties": {
-
-                    }
+            if rel_type not in edges:
+                edges[rel_type] = {
+                    "source": source_label,
+                    "target": target_label,
+                    "properties": []
                 }
 
-        # Now get the properties of the nodes and eges
-        query = '''
+        query = """
         MATCH (n)
         UNWIND labels(n) AS label
         UNWIND keys(n) AS key
         RETURN label, collect(DISTINCT key) AS properties
         ORDER BY label
-        '''
-
+        """
         results = self.run_query(query)
 
         for result in results:
             label = result["label"]
             properties_arr = result["properties"]
-            properties = {key: "string" for key in properties_arr if key != "id" and key != "tenant_id"}
-            nodes[label]["properties"] = properties
+            if label in nodes:
+                nodes[label]["properties"] = properties_arr
 
         response = {
-            "nodes": nodes,
+            "nodes": list(nodes.values()),
             "edges": edges
         }
+
         return response

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -9,6 +9,7 @@ import os
 from neo4j.graph import Node, Relationship
 from app.error import ThreadStopException
 import json
+import traceback
 
 load_dotenv()
 
@@ -163,11 +164,11 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 node_ids.add(target_var)
 
                 match_preds.append(
-                    f"{source_match}-[{predicate_id}:{predicate_type}]->{target_match}"
+                    f"{source_match}-[{predicate_id}:`{predicate_type}`]->{target_match}"
                 )
 
                 # Construct the MATCH clause
-                match_clause = f"MATCH {source_match}-[{predicate_id}:{predicate_type}]->{target_match}"
+                match_clause = f"MATCH {source_match}-[{predicate_id}:`{predicate_type}`]->{target_match}"
 
                 # Construct the WHERE clause if there are conditions
                 where_clause = f"WHERE {' AND '.join(tmp_where_preds)}" if len(tmp_where_preds) >= 1 else ''
@@ -290,10 +291,10 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             # count query
             count_clause = ''
             for node in query_clauses['list_of_node_ids']:
-                count_clause += f"COUNT(DISTINCT {node}) AS {node}_{node_map[node]['type']}, "
+                count_clause += f"COUNT(DISTINCT {node}) AS {node}_{node_map[node]['type'].replace(':', 'ZzZ')}, "
             for edge in query_clauses['predicates']:
                 edge_id = edge['predicate_id']
-                count_clause += f"COUNT(DISTINCT {edge_id}) AS {edge_id}_{predicate_map[edge_id]['type'].replace(' ', '_')}, "
+                count_clause += f"COUNT(DISTINCT {edge_id}) AS {edge_id}_{predicate_map[edge_id]['type'].replace(' ', '_').replace(':', 'ZzZ')}, "
             return_clause = "RETURN " + count_clause.rstrip(', ')
             label_count_query = f'''{match_no_clause} {where_no_clause} {match_clause} {where_clause} {return_clause}'''
         else:
@@ -320,9 +321,15 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
     def match_node(self, node, var_name):
         if node['id']:
-            return f"({var_name}:{node['type']} {{id: '{node['id']}', {{tenant_id: '{self.tenant_id}'}}}})"
+            if self.tenant_id:
+                return f"({var_name}:`{node['type']}` {{id: '{node['id']}', {{tenant_id: '{self.tenant_id}'}}}})"
+            else:
+                return f"({var_name}:`{node['type']}` {{id: '{node['id']}'}})"
         else:
-            return f"({var_name}:{node['type']} {{tenant_id: '{self.tenant_id}'}})"
+            if self.tenant_id:
+                return f"({var_name}:`{node['type']}` {{tenant_id: '{self.tenant_id}'}})"
+            else:
+                return f"({var_name}:`{node['type']}`)"
 
     def where_construct(self, node, var_name):
         properties = []
@@ -376,16 +383,16 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 if isinstance(item, neo4j.graph.Node):
                     node_id = f"{list(item.labels)[0]} {item['id']}"
                     if node_id not in node_dict:
+                        print("LABEL: ", list(item.labels)[0], "\n")
                         node_data = {
                             "data": {
                                 "id": node_id,
                                 "type": list(item.labels)[0],
                             }
                         }
-
                         for key, value in item.items():
                             if graph_components['properties']:
-                                if key != "id" and key != "synonyms":
+                                if key != "id" and key != "synonyms" and key != "type":
                                     node_data["data"][key] = value
                             else:
                                 if key in named_types:
@@ -393,7 +400,9 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                         if "name" not in node_data["data"]:
                             node_data["data"]["name"] = node_id
                         nodes.append(node_data)
+                        print("TYPE: ", node_data["data"]["type"])
                         if node_data["data"]["type"] not in node_type:
+                            print("TYPE: ", node_data["data"]["type"])
                             node_type.add(node_data["data"]["type"])
                             node_to_dict[node_data['data']['type']] = []
                         node_to_dict[node_data['data']
@@ -417,8 +426,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     if temp_relation_id in visited_relations:
                         continue
                     visited_relations.add(temp_relation_id)
-
                     for key, value in item.items():
+                        print("KEY: ", type(key))
                         if key == 'source':
                             edge_data["data"]["source_data"] = value
                         else:
@@ -429,7 +438,6 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                         edge_to_dict[edge_data['data']['label']] = []
                     edge_to_dict[edge_data['data']
                                  ['label']].append(edge_data)
-
         return (nodes, edges, node_to_dict, edge_to_dict)
 
     def process_result_count(self, node_and_edge_count, count_by_label, graph_components):
@@ -458,12 +466,14 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             # update node count aggregate dictionary with the count of each label
             for key, value in count_by_label.items():
                 node_type_key = '_'.join(key.split('_')[1:])
+                node_type_key = node_type_key.replace('ZzZ', ':')
                 if node_type_key in node_count_aggregate:
                     node_count_aggregate[node_type_key]['count'] += value
 
             # update edge count aggregate dictionary with the count of each label
             for key, value in count_by_label.items():
                 edge_type_key = '_'.join(key.split('_')[1:])
+                edge_type_key = edge_type_key.replace('ZzZ', ':')
                 if edge_type_key in ege_count_aggregate:
                     ege_count_aggregate[edge_type_key]['count'] += value
 
@@ -510,3 +520,70 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 node_and_edge_count, count_by_label, graph_components)
 
         return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
+
+    def get_schema(self):
+        query = "CALL db.schema.visualization()"
+
+        results = self.run_query(query)
+
+        results = results[0]
+
+        neo4j_nodes = results['nodes']
+        neo4j_edges = results['relationships']
+
+
+        edges = {}
+
+        nodes = {}
+        # process neo4j edges
+        for neo4j_edge in neo4j_edges:
+            source_node, target_node = neo4j_edge.nodes
+            source_label = next(iter(source_node.labels))
+            target_label = next(iter(target_node.labels))
+
+            nodes[source_label] = {
+                "label": source_label,
+                "properties": {
+                }
+            }
+
+            nodes[target_label] = {
+                "label": target_label,
+                "properties": {
+
+                }
+            }
+
+            id = neo4j_edge.type
+
+            if id not in edges:
+                edges[id] = {
+                    "source": next(iter(source_node.labels)),
+                    "target": next(iter(target_node.labels)),
+                    "properties": {
+
+                    }
+                }
+
+        # Now get the properties of the nodes and eges
+        query = '''
+        MATCH (n)
+        UNWIND labels(n) AS label
+        UNWIND keys(n) AS key
+        RETURN label, collect(DISTINCT key) AS properties
+        ORDER BY label
+        '''
+
+        results = self.run_query(query)
+
+        for result in results:
+            label = result["label"]
+            properties_arr = result["properties"]
+            properties = {key: "string" for key in properties_arr if key != "id" and key != "tenant_id"}
+            nodes[label]["properties"] = properties
+
+        response = {
+            "nodes": nodes,
+            "edges": edges
+        }
+        return response


### PR DESCRIPTION
- Replaced `CALL db.schema.visualization()` with a custom Cypher query to extract node and relationship schema.
- The new approach is slightly slower but provides **more accurate results**, avoiding ghost or inferred relationships present in older Neo4j versions.
- Enables querying of **public Neo4j APIs** without relying on APOC or admin procedures.